### PR TITLE
feat(aliases): ✨ add script to automatically configure useful shell a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proxmox Email Alert Setup
 
-This repository contains a script to easily configure email alerts on Proxmox servers using Gmail/G Suite.
+This repository contains scripts to easily configure email alerts and useful aliases on Proxmox servers.
 
 ## 📋 Features
 
@@ -9,13 +9,20 @@ This repository contains a script to easily configure email alerts on Proxmox se
 - Customization of sender name and address
 - Email sending test to verify the configuration
 - Step-by-step instructions for complete alert setup in Proxmox
+- Script to add useful aliases to your Proxmox shell
 
 ## 🚀 Quick Usage
 
-To run the script directly from GitHub:
+To run the email setup script directly from GitHub:
 
 ```bash
 bash -c "$(curl -fsS https://raw.githubusercontent.com/yacosta738/proxmox-email-alert-setup/main/proxmox-email-alert-setup.sh)"
+```
+
+To run the alias setup script directly from GitHub:
+
+```bash
+bash -c "$(curl -fsS https://raw.githubusercontent.com/yacosta738/proxmox-email-alert-setup/main/proxmox-alias-setup.sh)"
 ```
 
 > ⚠️ **Important**: Replace `yacosta738` with your GitHub username after forking or cloning this repository.
@@ -34,26 +41,33 @@ Before running the script, you'll need:
 
 If you prefer a manual installation:
 
-1. Clone this repository or download the script:
+1. Clone this repository or download the scripts:
 
    ```bash
    git clone https://github.com/yacosta738/proxmox-email-alert-setup.git
    cd proxmox-email-alert-setup
    ```
 
-2. Make the script executable:
+2. Make the scripts executable:
 
    ```bash
    chmod +x proxmox-email-alert-setup.sh
+   chmod +x proxmox-alias-setup.sh
    ```
 
-3. Run the script with root permissions:
+3. Run the scripts:
 
    ```bash
+   # For email alerts setup (requires root/sudo)
    sudo ./proxmox-email-alert-setup.sh
+   
+   # For adding useful aliases (can be run as regular user)
+   ./proxmox-alias-setup.sh
    ```
 
-## 🔍 What does the script do?
+## 🔍 What do the scripts do?
+
+### Email Alert Setup
 
 1. **Installs necessary dependencies**:
    - `libsasl2-modules`: Support for SASL authentication
@@ -70,6 +84,20 @@ If you prefer a manual installation:
 4. **Tests the configuration** by sending a test email
 
 5. **Provides instructions** to complete the setup in the Proxmox web interface
+
+### Alias Setup
+
+The `proxmox-alias-setup.sh` script adds convenient aliases to your shell configuration:
+
+1. **Automatically detects your shell** (Bash or Zsh)
+2. **Adds useful aliases** to your configuration file:
+   - `mv='mv -i'`: Interactive move to prevent accidental overwrites
+   - `aptup='apt update && apt upgrade'`: Quick package updates
+   - `lxcclean`: Clean unused LXC container data
+   - `lxcupdate`: Update all LXC containers
+   - `lxctrim`: Run FSTRIM on LXC containers
+   - `kernelclean`: Clean old kernel packages
+   - `updatecerts='pvecm updatecerts'`: Update Proxmox cluster certificates
 
 ## 🛠️ Additional Configuration in Proxmox
 

--- a/proxmox-alias-setup.sh
+++ b/proxmox-alias-setup.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Script to automatically add useful aliases to shell configuration file
+# For Proxmox VE servers
+# IMPORTANT: This script can be run by any user with permissions to their own home directory
+
+# Determine the shell configuration file (Bash or Zsh are most common)
+CONFIG_FILE=""
+SHELL_TYPE=""
+
+# First, attempt to detect based on SHELL variable
+CURRENT_SHELL=$(basename "$SHELL")
+
+if [ "$CURRENT_SHELL" = "bash" ]; then
+    CONFIG_FILE="$HOME/.bashrc"
+    SHELL_TYPE="Bash"
+elif [ "$CURRENT_SHELL" = "zsh" ]; then
+    CONFIG_FILE="$HOME/.zshrc"
+    SHELL_TYPE="Zsh"
+else
+    # If detection fails, attempt to detect by file existence
+    if [ -f "$HOME/.bashrc" ]; then
+        CONFIG_FILE="$HOME/.bashrc"
+        SHELL_TYPE="Bash (detected by file)"
+    elif [ -f "$HOME/.zshrc" ]; then
+        CONFIG_FILE="$HOME/.zshrc"
+        SHELL_TYPE="Zsh (detected by file)"
+    else
+        echo "Error: Could not automatically determine your shell configuration file (.bashrc or .zshrc)."
+        echo "Please edit this script and set the CONFIG_FILE variable manually."
+        exit 1
+    fi
+fi
+
+echo "Detected shell: $SHELL_TYPE"
+echo "Using configuration file: $CONFIG_FILE"
+echo ""
+
+# Check if wget is installed, as several aliases require it
+if ! command -v wget &> /dev/null; then
+    echo "Warning: Command 'wget' not found. Some aliases might not function."
+    echo "Consider installing wget (e.g., sudo apt update && sudo apt install wget)"
+    echo ""
+    # You could add a pause here if desired: read -p "Press Enter to continue..."
+fi
+
+# Add aliases to the end of the configuration file
+# Using 'cat << EOF >> ...' to better handle quotes and line breaks
+echo "Adding aliases to $CONFIG_FILE..."
+
+cat << EOF >> "$CONFIG_FILE"
+
+# --- Automatically added Proxmox aliases ---
+alias mv='mv -i'
+alias aptup='apt update && apt upgrade'
+alias lxcclean='bash -c "\$(wget -qLO - https://github.com/tteck/Proxmox/raw/main/misc/clean-lxcs.sh)"'
+alias lxcupdate='bash -c "\$(wget -qLO - https://github.com/tteck/Proxmox/raw/main/misc/update-lxcs.sh)"'
+alias lxctrim='bash -c "\$(wget -qLO - https://github.com/tteck/Proxmox/raw/main/misc/fstrim.sh)"'
+alias kernelclean='bash -c "\$(wget -qLO - https://github.com/tteck/Proxmox/raw/main/misc/kernel-clean.sh)"'
+alias updatecerts='pvecm updatecerts'
+# --- End of added aliases ---
+EOF
+
+# Check if the operation was successful
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "Success! Aliases have been added to $CONFIG_FILE."
+    echo ""
+    echo "For changes to take effect, you need to reload your shell configuration."
+    echo "You can do this by running one of the following commands:"
+    echo "  source $CONFIG_FILE"
+    echo "Or simply close and reopen your terminal."
+else
+    echo ""
+    echo "Error: There was a problem adding aliases to $CONFIG_FILE."
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This pull request introduces a new script, `proxmox-alias-setup.sh`, to add useful shell aliases for Proxmox VE servers and updates the documentation to reflect this addition. The most important changes include the creation of the alias setup script, updates to the `README.md` to include instructions for using the new script, and details about the aliases provided.

### New Feature: Alias Setup Script
* Added `proxmox-alias-setup.sh`, a script that detects the user's shell (`bash` or `zsh`) and adds a set of predefined aliases to the relevant configuration file. The script ensures compatibility and provides feedback to the user during execution.

### Documentation Updates
* Updated `README.md` to reflect the addition of the alias setup script, including instructions for downloading, making executable, and running the script.
* Added a new section in `README.md` under "What do the scripts do?" to describe the functionality of the alias setup script and list the aliases it provides.
* Adjusted existing text in `README.md` to distinguish between the email alert setup script and the alias setup script. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R12-R27)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a script to automatically add useful aliases for Proxmox servers, enhancing command-line convenience for users.
- **Documentation**
  - Updated the README with instructions for using the new alias setup script, including usage examples and detailed explanations of the available aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->